### PR TITLE
Add Nix packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ sign.keystore
 
 # state files
 *.state
+
+# Nix build symlinks
+result

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,1 @@
+{ pkgs ? import <nixpkgs> { } }: pkgs.callPackage (import ./katzen.nix { }) { }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1681215634,
+        "narHash": "sha256-dI0SsSWb7ksK3OtTCf61vdlBhok838aIpwQ2EUM+jhY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5a156c2e89c1eca09b40bcdcee86760e0e4d79a9",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
       legacyPackages = lib.attrsets.mapAttrs (system: pkgs:
         pkgs.appendOverlays (builtins.attrValues self.overlays)) {
           inherit (nixpkgs.legacyPackages)
-            i686-linux x86_64-linux aarch64-linux;
+            x86_64-linux aarch64-linux;
         };
 
       packages = lib.attrsets.mapAttrs (system: pkgs: rec {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "Katzenpost development flake";
+
+  outputs = { self, nixpkgs }:
+    let inherit (nixpkgs) lib;
+    in {
+
+      overlays.default = final: prev: {
+        katzen = final.callPackage (import ./katzen.nix {
+          src = self;
+          version = "unstable-${self.lastModifiedDate}";
+        }) { };
+      };
+
+      legacyPackages = lib.attrsets.mapAttrs (system: pkgs:
+        pkgs.appendOverlays (builtins.attrValues self.overlays)) {
+          inherit (nixpkgs.legacyPackages)
+            i686-linux x86_64-linux aarch64-linux;
+        };
+
+      packages = lib.attrsets.mapAttrs (system: pkgs: rec {
+        inherit (pkgs) katzen;
+        default = katzen;
+      }) self.legacyPackages;
+
+      checks = self.packages;
+    };
+
+}

--- a/katzen.nix
+++ b/katzen.nix
@@ -1,0 +1,61 @@
+{ src ? ./., version ? "unstable" }:
+{ lib, buildGoModule, fetchFromGitHub, copyDesktopItems, makeDesktopItem
+, pkg-config, librsvg, libGL, libX11, libXfixes, libxkbcommon, vulkan-headers
+, wayland, xorg }:
+
+buildGoModule rec {
+  pname = "katzen";
+  inherit src version;
+
+  vendorHash = "sha256-4/AteWLY9biTspcXcyzK1gNwzkQfFoNq89yJheswf4s=";
+  # This hash is may drift from the actual vendoring and break the build,
+  # see https://nixos.org/manual/nixpkgs/unstable/#ssec-language-go.
+
+  nativeBuildInputs = [ pkg-config copyDesktopItems librsvg ];
+  buildInputs = [
+    libGL
+    libX11
+    libXfixes
+    libxkbcommon
+    vulkan-headers
+    wayland
+    xorg.libXcursor
+  ];
+
+  CGO_CFLAGS_ALLOW = "-DPARAMS=sphincs-shake-256f";
+
+  postInstall = ''
+    ## Both of the configs are embedded in the binary; "without_tor" being the default.
+    ## Another config may be specified by using '-f' flag.
+    install -D -t $out/share/ ./default_config_without_tor.toml
+    install -D -t $out/share/ ./default_config_with_tor.toml
+
+    install -D \
+      ./assets/katzenpost_logo.svg \
+      $out/share/icons/hicolor/scalable/apps/${pname}.svg
+
+    mkdir -p $out/share/icons/hicolor/48x48/apps
+    rsvg-convert \
+      --output $out/share/icons/hicolor/48x48/apps/${pname}.png \
+      --width 48 --height 48 \
+      ./assets/katzenpost_logo.svg
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = pname;
+      icon = pname;
+      desktopName = "Katzen";
+      genericName = meta.description;
+      categories = [ "Chat" "Network" ];
+    })
+  ];
+
+  meta = with lib; {
+    description = "Traffic analysis resistant messaging";
+    homepage = "https://katzenpost.mixnetworks.org/";
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ ehmry ];
+  };
+}


### PR DESCRIPTION
Add some metadata for building a Nix package.

After merging the package can be built deterministically with `nix build github:katzenpost/katzen` (if flake mode is locally enabled, not yet the default for Nix).

To test the build run `nix build github:ehmry/katzen/flake -L`.